### PR TITLE
initial implementation

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,22 @@
+#
+# Build and test on pull request
+#
+name: Pull Request
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.5'
+      - name: Build
+        run: go build -v ./...
+      - name: Test
+        run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Temporary files
 .*.swp
+
+# IDE files
+/.idea

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -5,17 +5,17 @@ For general information about contributing changes, see the
 
 ## How it Works
 
-Describe the internal mechanisms necessary for developers to understand how
-to get started making changes.
+The provider uses the Titan `remote-sdk-go` to provide interfaces for
+Titan to use.
 
 ## Building
 
-Describe how to build the project.
+Run `go build -v ./...`.
 
 ## Testing
 
-Describe how to test the project.
+Run `go test -v ./...`.
 
 ## Releasing
 
-Describe how to generate new releases.
+Push a tag of the form `v<X>.<Y>.<Z>`, and publish the draft release in GitHub.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# About this Project
+# Titan S3 Provider
 
-Describe the project for users.
+This is a basic Titan S3 provider. For more information on how it works,
+consult the titan documentation.
 
 ## Contributing
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/titan-data/s3-remote-go
 
 require (
+	github.com/aws/aws-sdk-go v1.27.0
 	github.com/stretchr/testify v1.4.0
 	github.com/titan-data/remote-sdk-go v0.0.3
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/titan-data/s3-remote-go
+
+require (
+	github.com/stretchr/testify v1.4.0
+	github.com/titan-data/remote-sdk-go v0.0.3
+)
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/titan-data/remote-sdk-go v0.0.2 h1:NEta4CwcUPj7PGbbxvpxIXem7t0EIbXBKegJsy1hafE=
+github.com/titan-data/remote-sdk-go v0.0.2/go.mod h1:b4McaOFiLYWv2/wCQW/sE2BcCSNz/Ae6iKKEtqw703w=
+github.com/titan-data/remote-sdk-go v0.0.3 h1:kGLc7JP7znTcXyl3gRML2jEST99ebdhz0Cn+nVdL6SQ=
+github.com/titan-data/remote-sdk-go v0.0.3/go.mod h1:b4McaOFiLYWv2/wCQW/sE2BcCSNz/Ae6iKKEtqw703w=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,12 @@
+github.com/aws/aws-sdk-go v1.27.0 h1:0xphMHGMLBrPMfxR2AmVjZKcMEESEgWF8Kru94BNByk=
+github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/s3/mock_test.go
+++ b/s3/mock_test.go
@@ -1,3 +1,6 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
 package s3
 
 import (

--- a/s3/mock_test.go
+++ b/s3/mock_test.go
@@ -1,0 +1,20 @@
+package s3
+
+import (
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockProvider struct {
+	mock.Mock
+}
+
+func (p *MockProvider) Retrieve() (credentials.Value, error) {
+	args := p.Called()
+	return args.Get(0).(credentials.Value), args.Error(1)
+}
+
+func (p *MockProvider) IsExpired() bool {
+	args := p.Called()
+	return args.Bool(0)
+}

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -71,8 +71,23 @@ func (s s3webRemote) FromURL(url *url.URL, additionalProperties map[string]strin
 }
 
 func (s s3webRemote) ToURL(properties map[string]interface{}) (string, map[string]string, error) {
-	u := properties["url"].(string)
-	return strings.Replace(u, "http", "s3web", 1), map[string]string{}, nil
+	u := fmt.Sprintf("s3://%s", properties["bucket"])
+	if properties["path"] != nil {
+		u += fmt.Sprintf("/%s", properties["path"])
+	}
+
+	params := map[string]string{}
+	if properties["accessKey"] != nil {
+		params["accessKey"] = properties["accessKey"].(string)
+	}
+	if properties["secretKey"] != nil {
+		params["secretKey"] = properties["secretKey"].(string)
+	}
+	if properties["region"] != nil {
+		params["region"] = properties["region"].(string)
+	}
+
+	return u, params, nil
 }
 
 func (s s3webRemote) GetParameters(remoteProperties map[string]interface{}) (map[string]interface{}, error) {

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+package s3
+
+import (
+	"errors"
+	"fmt"
+	"github.com/titan-data/remote-sdk-go/remote"
+	"net/url"
+	"strings"
+)
+
+type s3webRemote struct {
+}
+
+func (s s3webRemote) Type() string {
+	return "s3"
+}
+
+func (s s3webRemote) FromURL(url *url.URL, additionalProperties map[string]string) (map[string]interface{}, error) {
+	if url.Scheme != "s3" {
+		return nil, errors.New("invalid remote scheme")
+	}
+
+	if url.User != nil {
+		return nil, errors.New("remote username and password cannot be specified")
+	}
+
+	if url.Port() != "" {
+		return nil, errors.New("remote port cannot be specified")
+	}
+
+	if url.Hostname() == "" {
+		return nil, errors.New("missing remote bucket name")
+	}
+
+	accessKey := additionalProperties["accessKey"]
+	secretKey := additionalProperties["secretKey"]
+	region := additionalProperties["region"]
+	for k := range additionalProperties {
+		if k != "accessKey" && k != "secretKey" && k != "region" {
+			return nil, errors.New(fmt.Sprintf("invalid remote property '%s'", k))
+		}
+	}
+
+	if (accessKey == "" && secretKey != "") || (accessKey != "" && secretKey == "") {
+		return nil, errors.New(fmt.Sprintf("either both of accessKey and secretKey must be set, or neither"))
+	}
+
+	path := url.Path
+	if strings.Index(path, "/") == 0 {
+		path = path[1:]
+	}
+
+	result := map[string]interface{}{"bucket": url.Hostname()}
+	if accessKey != "" {
+		result["accessKey"] = accessKey
+	}
+	if secretKey != "" {
+		result["secretKey"] = secretKey
+	}
+	if region != "" {
+		result["region"] = region
+	}
+	if path != "" {
+		result["path"] = path
+	}
+
+	return result, nil
+}
+
+func (s s3webRemote) ToURL(properties map[string]interface{}) (string, map[string]string, error) {
+	u := properties["url"].(string)
+	return strings.Replace(u, "http", "s3web", 1), map[string]string{}, nil
+}
+
+func (s s3webRemote) GetParameters(remoteProperties map[string]interface{}) (map[string]interface{}, error) {
+	return map[string]interface{}{}, nil
+}
+
+func init() {
+	remote.Register(s3webRemote{})
+}

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -4,9 +4,14 @@
 package s3
 
 import (
+	"errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/titan-data/remote-sdk-go/remote"
 	"net/url"
+	"os"
 	"testing"
 )
 
@@ -139,60 +144,85 @@ func TestWithRegsion(t *testing.T) {
 	assert.Equal(t, "REGION", props["region"])
 }
 
-/*
-   "s3 get parameters succeeds" {
-       val params = client.getParameters(mapOf("bucket" to "bucket", "path" to "path",
-               "accessKey" to "ACCESS", "secretKey" to "SECRET", "region" to "REGION"))
-       params["accessKey"] shouldBe "ACCESS"
-       params["secretKey"] shouldBe "SECRET"
-       params["region"] shouldBe "REGION"
-   }
-
-   "getting credentials from environment succeeds" {
-       withEnvironment(mapOf("AWS_ACCESS_KEY_ID" to "accessKey", "AWS_SECRET_ACCESS_KEY" to "secretKey",
-               "AWS_REGION" to "us-west-2", "AWS_SESSION_TOKEN" to "sessionToken"), OverrideMode.SetOrOverride) {
-           System.getenv("AWS_ACCESS_KEY_ID") shouldBe "accessKey"
-           System.getenv("AWS_SECRET_ACCESS_KEY") shouldBe "secretKey"
-           System.getenv("AWS_REGION") shouldBe "us-west-2"
-           System.getenv("AWS_SESSION_TOKEN") shouldBe "sessionToken"
-           val params = client.getParameters(mapOf("bucket" to "bucket", "path" to "path"))
-           params["accessKey"] shouldBe "accessKey"
-           params["secretKey"] shouldBe "secretKey"
-           params["sessionToken"] shouldBe "sessionToken"
-           params["region"] shouldBe "us-west-2"
-       }
-   }
-
-   "failure to resolve AWS credentials fails" {
-       mockkStatic(DefaultCredentialsProvider::class)
-       val credentialsProvider = mockk<DefaultCredentialsProvider>()
-       every { DefaultCredentialsProvider.create() } returns credentialsProvider
-       every { credentialsProvider.resolveCredentials() } returns null
-       shouldThrow<IllegalArgumentException> {
-           client.getParameters(mapOf("bucket" to "bucket", "path" to "path"))
-       }
-   }
-
-   "AWS credentials without access key fails" {
-       mockkStatic(DefaultCredentialsProvider::class)
-       val credentialsProvider = mockk<DefaultCredentialsProvider>()
-       every { DefaultCredentialsProvider.create() } returns credentialsProvider
-       val credentials = mockk<AwsCredentials>()
-       every { credentialsProvider.resolveCredentials() } returns credentials
-       every { credentials.accessKeyId() } returns null
-       every { credentials.secretAccessKey() } returns null
-       shouldThrow<IllegalArgumentException> {
-           client.getParameters(mapOf("bucket" to "bucket", "path" to "path"))
-       }
-   }
-*/
-
-/*
-
-
-func TestParameters(t *testing.T) {
-	r := remote.Get("s3web")
-	props, _ := r.GetParameters(map[string]interface{}{"url": "http://host/path"})
-	assert.Empty(t, props)
+func TestGetParameters(t *testing.T) {
+	r := remote.Get("s3")
+	props, _ := r.GetParameters(map[string]interface{}{"bucket": "bucket", "path": "path",
+		"accessKey": "ACCESS", "secretKey": "SECRET", "region": "REGION"})
+	assert.Equal(t, "ACCESS", props["accessKey"])
+	assert.Equal(t, "SECRET", props["secretKey"])
+	assert.Equal(t, "REGION", props["region"])
 }
-*/
+
+func TestGetParametersEnvironment(t *testing.T) {
+	r := remote.Get("s3")
+	_ = os.Setenv("AWS_ACCESS_KEY_ID", "ACCESS")
+	_ = os.Setenv("AWS_SECRET_ACCESS_KEY", "SECRET")
+	_ = os.Setenv("AWS_REGION", "us-west-2")
+	_ = os.Setenv("AWS_SESSION_TOKEN", "TOKEN")
+	props, _ := r.GetParameters(map[string]interface{}{"bucket": "bucket", "path": "path"})
+	assert.Equal(t, "ACCESS", props["accessKey"])
+	assert.Equal(t, "SECRET", props["secretKey"])
+	assert.Equal(t, "us-west-2", props["region"])
+	assert.Equal(t, "TOKEN", props["sessionToken"])
+}
+
+func TestBadNewSession(t *testing.T) {
+	r := remote.Get("s3")
+	newSession = func(cfgs ...*aws.Config) (session *session.Session, err error) {
+		return nil, errors.New("err")
+	}
+	_, err := r.GetParameters(map[string]interface{}{"bucket": "bucket", "path": "path"})
+	assert.NotNil(t, err)
+	newSession = session.NewSession
+}
+
+func TestBadConfigCredentials(t *testing.T) {
+	r := remote.Get("s3")
+	p := new(MockProvider)
+	p.On("Retrieve").Return(credentials.Value{}, errors.New("err"))
+	newSession = func(cfgs ...*aws.Config) (*session.Session, error) {
+		return &session.Session{
+			Config: &aws.Config{
+				Credentials: credentials.NewCredentials(p),
+			},
+		}, nil
+	}
+	_, err := r.GetParameters(map[string]interface{}{"bucket": "bucket", "path": "path"})
+	assert.NotNil(t, err)
+	newSession = session.NewSession
+}
+
+func TestBadCredentialsAccessKey(t *testing.T) {
+	r := remote.Get("s3")
+	p := new(MockProvider)
+	p.On("Retrieve").Return(credentials.Value{}, nil)
+	newSession = func(cfgs ...*aws.Config) (*session.Session, error) {
+		return &session.Session{
+			Config: &aws.Config{
+				Credentials: credentials.NewCredentials(p),
+			},
+		}, nil
+	}
+	_, err := r.GetParameters(map[string]interface{}{"bucket": "bucket", "path": "path"})
+	assert.NotNil(t, err)
+	newSession = session.NewSession
+}
+
+func TestBadCredentialsRegion(t *testing.T) {
+	r := remote.Get("s3")
+	p := new(MockProvider)
+	p.On("Retrieve").Return(credentials.Value{
+		AccessKeyID:     "ACCESS",
+		SecretAccessKey: "SECRET",
+	}, nil)
+	newSession = func(cfgs ...*aws.Config) (*session.Session, error) {
+		return &session.Session{
+			Config: &aws.Config{
+				Credentials: credentials.NewCredentials(p),
+			},
+		}, nil
+	}
+	_, err := r.GetParameters(map[string]interface{}{"bucket": "bucket", "path": "path"})
+	assert.NotNil(t, err)
+	newSession = session.NewSession
+}

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -1,0 +1,243 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+package s3
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/titan-data/remote-sdk-go/remote"
+	"net/url"
+	"testing"
+)
+
+func TestRegistered(t *testing.T) {
+	r := remote.Get("s3")
+	assert.Equal(t, "s3", r.Type())
+}
+
+func TestFromURL(t *testing.T) {
+	r := remote.Get("s3")
+	u, _ := url.Parse("s3://bucket/object/path")
+	props, _ := r.FromURL(u, map[string]string{})
+	assert.Equal(t, "bucket", props["bucket"])
+	assert.Equal(t, "object/path", props["path"])
+	assert.Nil(t, props["accessKey"])
+	assert.Nil(t, props["secretKey"])
+	assert.Nil(t, props["region"])
+}
+
+func TestNoPath(t *testing.T) {
+	r := remote.Get("s3")
+	u, _ := url.Parse("s3://bucket")
+	props, _ := r.FromURL(u, map[string]string{})
+	assert.Equal(t, "bucket", props["bucket"])
+	assert.Nil(t, props["path"])
+	assert.Nil(t, props["accessKey"])
+	assert.Nil(t, props["secretKey"])
+	assert.Nil(t, props["region"])
+}
+
+func TestBadScheme(t *testing.T) {
+	r := remote.Get("s3")
+	u, _ := url.Parse("s3")
+	_, err := r.FromURL(u, map[string]string{})
+	assert.NotNil(t, err)
+}
+
+func TestBadSchemeName(t *testing.T) {
+	r := remote.Get("s3")
+	u, _ := url.Parse("foo://bucket/path")
+	_, err := r.FromURL(u, map[string]string{})
+	assert.NotNil(t, err)
+}
+
+func TestBadProperty(t *testing.T) {
+	r := remote.Get("s3")
+	u, _ := url.Parse("s3://bucket/object/path")
+	_, err := r.FromURL(u, map[string]string{"foo": "bar"})
+	assert.NotNil(t, err)
+}
+
+func TestBadUser(t *testing.T) {
+	r := remote.Get("s3")
+	u, _ := url.Parse("s3://user@bucket/object/path")
+	_, err := r.FromURL(u, map[string]string{})
+	assert.NotNil(t, err)
+}
+
+func TestBadUserPassword(t *testing.T) {
+	r := remote.Get("s3")
+	u, _ := url.Parse("s3://user:password@bucket/object/path")
+	_, err := r.FromURL(u, map[string]string{})
+	assert.NotNil(t, err)
+}
+
+func TestBadPort(t *testing.T) {
+	r := remote.Get("s3")
+	u, _ := url.Parse("s3://bucket:80/object/path")
+	_, err := r.FromURL(u, map[string]string{})
+	assert.NotNil(t, err)
+}
+
+func TestBadMissingBucket(t *testing.T) {
+	r := remote.Get("s3")
+	u, _ := url.Parse("s3:///object/path")
+	_, err := r.FromURL(u, map[string]string{})
+	assert.NotNil(t, err)
+}
+
+func TestProperties(t *testing.T) {
+	r := remote.Get("s3")
+	u, _ := url.Parse("s3://bucket/object/path")
+	props, _ := r.FromURL(u, map[string]string{
+		"accessKey": "ACCESS", "secretKey": "SECRET", "region": "REGION",
+	})
+	assert.Equal(t, "bucket", props["bucket"])
+	assert.Equal(t, "object/path", props["path"])
+	assert.Equal(t, "ACCESS", props["accessKey"])
+	assert.Equal(t, "SECRET", props["secretKey"])
+	assert.Equal(t, "REGION", props["region"])
+}
+
+func TestBadAccessKeyOnly(t *testing.T) {
+	r := remote.Get("s3")
+	u, _ := url.Parse("s3://bucket/object/path")
+	_, err := r.FromURL(u, map[string]string{"accessKey": "ACCESS"})
+	assert.NotNil(t, err)
+}
+
+func TestBadSecretKeyOnly(t *testing.T) {
+	r := remote.Get("s3")
+	u, _ := url.Parse("s3://bucket/object/path")
+	_, err := r.FromURL(u, map[string]string{"secretKey": "ACCESS"})
+	assert.NotNil(t, err)
+}
+
+/*
+   "s3 remote to URI succeeds" {
+       val (uri, props) = client.toUri(mapOf("bucket" to "bucket", "path" to "path"))
+       uri shouldBe "s3://bucket/path"
+       props.size shouldBe 0
+   }
+
+   "s3 remote with keys to URI succeeds" {
+       val (uri, props) = client.toUri(mapOf("bucket" to "bucket", "path" to "path",
+               "accessKey" to "ACCESS", "secretKey" to "SECRET"))
+       uri shouldBe "s3://bucket/path"
+       props.size shouldBe 2
+       props["accessKey"] shouldBe "ACCESS"
+       props["secretKey"] shouldBe "*****"
+   }
+
+   "s3 remote with region to URI succeeds" {
+       val (uri, props) = client.toUri(mapOf("bucket" to "bucket", "path" to "path",
+               "region" to "REGION"))
+       uri shouldBe "s3://bucket/path"
+       props.size shouldBe 1
+       props["region"] shouldBe "REGION"
+   }
+
+   "s3 get parameters succeeds" {
+       val params = client.getParameters(mapOf("bucket" to "bucket", "path" to "path",
+               "accessKey" to "ACCESS", "secretKey" to "SECRET", "region" to "REGION"))
+       params["accessKey"] shouldBe "ACCESS"
+       params["secretKey"] shouldBe "SECRET"
+       params["region"] shouldBe "REGION"
+   }
+
+   "getting credentials from environment succeeds" {
+       withEnvironment(mapOf("AWS_ACCESS_KEY_ID" to "accessKey", "AWS_SECRET_ACCESS_KEY" to "secretKey",
+               "AWS_REGION" to "us-west-2", "AWS_SESSION_TOKEN" to "sessionToken"), OverrideMode.SetOrOverride) {
+           System.getenv("AWS_ACCESS_KEY_ID") shouldBe "accessKey"
+           System.getenv("AWS_SECRET_ACCESS_KEY") shouldBe "secretKey"
+           System.getenv("AWS_REGION") shouldBe "us-west-2"
+           System.getenv("AWS_SESSION_TOKEN") shouldBe "sessionToken"
+           val params = client.getParameters(mapOf("bucket" to "bucket", "path" to "path"))
+           params["accessKey"] shouldBe "accessKey"
+           params["secretKey"] shouldBe "secretKey"
+           params["sessionToken"] shouldBe "sessionToken"
+           params["region"] shouldBe "us-west-2"
+       }
+   }
+
+   "failure to resolve AWS credentials fails" {
+       mockkStatic(DefaultCredentialsProvider::class)
+       val credentialsProvider = mockk<DefaultCredentialsProvider>()
+       every { DefaultCredentialsProvider.create() } returns credentialsProvider
+       every { credentialsProvider.resolveCredentials() } returns null
+       shouldThrow<IllegalArgumentException> {
+           client.getParameters(mapOf("bucket" to "bucket", "path" to "path"))
+       }
+   }
+
+   "AWS credentials without access key fails" {
+       mockkStatic(DefaultCredentialsProvider::class)
+       val credentialsProvider = mockk<DefaultCredentialsProvider>()
+       every { DefaultCredentialsProvider.create() } returns credentialsProvider
+       val credentials = mockk<AwsCredentials>()
+       every { credentialsProvider.resolveCredentials() } returns credentials
+       every { credentials.accessKeyId() } returns null
+       every { credentials.secretAccessKey() } returns null
+       shouldThrow<IllegalArgumentException> {
+           client.getParameters(mapOf("bucket" to "bucket", "path" to "path"))
+       }
+   }
+*/
+
+/*
+
+func TestNoPath(t *testing.T) {
+	r := remote.Get("s3web")
+	u, _ := url.Parse("s3web://host")
+	props, _ := r.FromURL(u, map[string]string{})
+	assert.Equal(t, "http://host", props["url"])
+}
+
+func TestBadProperty(t *testing.T) {
+	r := remote.Get("s3web")
+	u, _ := url.Parse("s3web://host")
+	_, err := r.FromURL(u, map[string]string{"a": "b"})
+	assert.NotNil(t, err)
+}
+
+func TestBadUser(t *testing.T) {
+	r := remote.Get("s3web")
+	u, _ := url.Parse("s3web://user@host/path")
+	_, err := r.FromURL(u, map[string]string{})
+	assert.NotNil(t, err)
+}
+
+func TestBadUserPassword(t *testing.T) {
+	r := remote.Get("s3web")
+	u, _ := url.Parse("s3web://user:password@host/path")
+	_, err := r.FromURL(u, map[string]string{})
+	assert.NotNil(t, err)
+}
+
+func TestBadNoHost(t *testing.T) {
+	r := remote.Get("s3web")
+	u, _ := url.Parse("s3web:///path")
+	_, err := r.FromURL(u, map[string]string{})
+	assert.NotNil(t, err)
+}
+
+func TestPort(t *testing.T) {
+	r := remote.Get("s3web")
+	u, _ := url.Parse("s3web://host:1023/object/path")
+	props, _ := r.FromURL(u, map[string]string{})
+	assert.Equal(t, "http://host:1023/object/path", props["url"])
+}
+
+func TestToURL(t *testing.T) {
+	r := remote.Get("s3web")
+	u, props, _ := r.ToURL(map[string]interface{}{"url": "http://host/path"})
+	assert.Equal(t, "s3web://host/path", u)
+	assert.Empty(t, props)
+}
+
+func TestParameters(t *testing.T) {
+	r := remote.Get("s3web")
+	props, _ := r.GetParameters(map[string]interface{}{"url": "http://host/path"})
+	assert.Empty(t, props)
+}
+*/

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -113,30 +113,33 @@ func TestBadSecretKeyOnly(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestToURL(t *testing.T) {
+	r := remote.Get("s3")
+	u, props, _ := r.ToURL(map[string]interface{}{"bucket": "bucket", "path": "path"})
+	assert.Equal(t, "s3://bucket/path", u)
+	assert.Empty(t, props)
+}
+
+func TestWithKeys(t *testing.T) {
+	r := remote.Get("s3")
+	u, props, _ := r.ToURL(map[string]interface{}{"bucket": "bucket", "path": "path",
+		"accessKey": "ACCESS", "secretKey": "SECRET"})
+	assert.Equal(t, "s3://bucket/path", u)
+	assert.Len(t, props, 2)
+	assert.Equal(t, "ACCESS", props["accessKey"])
+	assert.Equal(t, "SECRET", props["secretKey"])
+}
+
+func TestWithRegsion(t *testing.T) {
+	r := remote.Get("s3")
+	u, props, _ := r.ToURL(map[string]interface{}{"bucket": "bucket", "path": "path",
+		"region": "REGION"})
+	assert.Equal(t, "s3://bucket/path", u)
+	assert.Len(t, props, 1)
+	assert.Equal(t, "REGION", props["region"])
+}
+
 /*
-   "s3 remote to URI succeeds" {
-       val (uri, props) = client.toUri(mapOf("bucket" to "bucket", "path" to "path"))
-       uri shouldBe "s3://bucket/path"
-       props.size shouldBe 0
-   }
-
-   "s3 remote with keys to URI succeeds" {
-       val (uri, props) = client.toUri(mapOf("bucket" to "bucket", "path" to "path",
-               "accessKey" to "ACCESS", "secretKey" to "SECRET"))
-       uri shouldBe "s3://bucket/path"
-       props.size shouldBe 2
-       props["accessKey"] shouldBe "ACCESS"
-       props["secretKey"] shouldBe "*****"
-   }
-
-   "s3 remote with region to URI succeeds" {
-       val (uri, props) = client.toUri(mapOf("bucket" to "bucket", "path" to "path",
-               "region" to "REGION"))
-       uri shouldBe "s3://bucket/path"
-       props.size shouldBe 1
-       props["region"] shouldBe "REGION"
-   }
-
    "s3 get parameters succeeds" {
        val params = client.getParameters(mapOf("bucket" to "bucket", "path" to "path",
                "accessKey" to "ACCESS", "secretKey" to "SECRET", "region" to "REGION"))
@@ -186,54 +189,6 @@ func TestBadSecretKeyOnly(t *testing.T) {
 
 /*
 
-func TestNoPath(t *testing.T) {
-	r := remote.Get("s3web")
-	u, _ := url.Parse("s3web://host")
-	props, _ := r.FromURL(u, map[string]string{})
-	assert.Equal(t, "http://host", props["url"])
-}
-
-func TestBadProperty(t *testing.T) {
-	r := remote.Get("s3web")
-	u, _ := url.Parse("s3web://host")
-	_, err := r.FromURL(u, map[string]string{"a": "b"})
-	assert.NotNil(t, err)
-}
-
-func TestBadUser(t *testing.T) {
-	r := remote.Get("s3web")
-	u, _ := url.Parse("s3web://user@host/path")
-	_, err := r.FromURL(u, map[string]string{})
-	assert.NotNil(t, err)
-}
-
-func TestBadUserPassword(t *testing.T) {
-	r := remote.Get("s3web")
-	u, _ := url.Parse("s3web://user:password@host/path")
-	_, err := r.FromURL(u, map[string]string{})
-	assert.NotNil(t, err)
-}
-
-func TestBadNoHost(t *testing.T) {
-	r := remote.Get("s3web")
-	u, _ := url.Parse("s3web:///path")
-	_, err := r.FromURL(u, map[string]string{})
-	assert.NotNil(t, err)
-}
-
-func TestPort(t *testing.T) {
-	r := remote.Get("s3web")
-	u, _ := url.Parse("s3web://host:1023/object/path")
-	props, _ := r.FromURL(u, map[string]string{})
-	assert.Equal(t, "http://host:1023/object/path", props["url"])
-}
-
-func TestToURL(t *testing.T) {
-	r := remote.Get("s3web")
-	u, props, _ := r.ToURL(map[string]interface{}{"url": "http://host/path"})
-	assert.Equal(t, "s3web://host/path", u)
-	assert.Empty(t, props)
-}
 
 func TestParameters(t *testing.T) {
 	r := remote.Get("s3web")


### PR DESCRIPTION
## Proposed Changes

This is an initial implementation of the (client-only) s3 remote provider in go.

## Testing

`go test ./...` and verified 100% coverage.
