### PR TITLE
load AWS configuration from shared config

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -96,7 +96,7 @@ func (s s3webRemote) ToURL(properties map[string]interface{}) (string, map[strin
 	return u, params, nil
 }
 
-var newSession = session.NewSession
+var newSession = session.NewSessionWithOptions
 
 func (s s3webRemote) GetParameters(remoteProperties map[string]interface{}) (map[string]interface{}, error) {
 	result := map[string]interface{}{}
@@ -111,7 +111,7 @@ func (s s3webRemote) GetParameters(remoteProperties map[string]interface{}) (map
 	}
 
 	if result["accessKey"] == nil || result["secretKey"] == nil || result["region"] == nil {
-		sess, err := newSession()
+		sess, err := newSession(session.Options{SharedConfigState: session.SharedConfigEnable})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Proposed Changes

By default, the AWS SDK for go only loads configuration from `~/.aws/credentials`, and requires you to set the `AWS_SDK_LOAD_CONFIG` variable to have it load `~/.aws/config` as well. Since AWS instructs you to save the region in `~/.aws/config`, this is counter-intuitive default behavior. Thankfully, there's an option to change the default behavior regardless of the environment variable. This uses this alternate session creation mechanism, and adds a test to make sure everything works.

## Testing

`go test ./...`